### PR TITLE
Stitching Integration

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -555,9 +555,9 @@ SHOW_TILED_PREVIEW = True
 PRVIEW_DOWNSAMPLE_FACTOR = 5
 
 # Emission filter wheel
-USE_ZABER_EMISSION_FILTER_WHEEL = False
+USE_ZABER_EMISSION_FILTER_WHEEL = True
 # need redefine it with real USB device serial number
-FILTER_CONTROLLER_SERIAL_NUMBER = 'A10NFZP8' 
+FILTER_CONTROLLER_SERIAL_NUMBER = 'A10NG007' 
 
 ##########################################################
 #### start of loading machine specific configurations ####

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -568,7 +568,7 @@ CHANNEL_COLORS_MAP = {
 }
 
 # Emission filter wheel
-USE_ZABER_EMISSION_FILTER_WHEEL = True
+USE_ZABER_EMISSION_FILTER_WHEEL = False
 # need redefine it with real USB device serial number
 FILTER_CONTROLLER_SERIAL_NUMBER = 'A10NG007' 
 

--- a/software/control/camera.py
+++ b/software/control/camera.py
@@ -486,6 +486,8 @@ class Camera_Simulation(object):
         self.OffsetX = 0
         self.OffsetY = 0
 
+        self.new_image_callback_external
+
 
     def open(self,index=0):
         pass

--- a/software/control/core.py
+++ b/software/control/core.py
@@ -721,7 +721,7 @@ class NavigationController(QObject):
         offset_y = (click_y * PRVIEW_DOWNSAMPLE_FACTOR) % tile_height
         offset_x_centered = int(offset_x - tile_width / 2)
         offset_y_centered = int(tile_height / 2 - offset_y)
-        self.move_from_click(offset_x_centered, ry_centered, tile_width, tile_height)
+        self.move_from_click(offset_x_centered, offset_y_centered, tile_width, tile_height)
 
     def move_from_click(self, click_x, click_y, image_width, image_height):
         if self.click_to_move:

--- a/software/control/core.py
+++ b/software/control/core.py
@@ -391,7 +391,8 @@ class Configuration:
             self._pixel_format_options = self.pixel_format
 
 class LiveController(QObject):
-
+    DISABLE_FILTER_WHEEL_MOVEMENT = False
+    
     def __init__(self,camera,microcontroller,configurationManager,parent=None,control_illumination=True,use_internal_timer_for_hardware_trigger=True,for_displacement_measurement=False):
         QObject.__init__(self)
         self.microscope = parent
@@ -504,7 +505,7 @@ class LiveController(QObject):
                 except Exception as e:
                     print('not setting emission filter position due to ' + str(e))
 
-                if USE_ZABER_EMISSION_FILTER_WHEEL:
+                if USE_ZABER_EMISSION_FILTER_WHEEL and not self.DISABLE_FILTER_WHEEL_MOVEMENT:
                     try:
                         self.microscope.emission_filter_wheel.set_emission_filter(str(self.currentConfiguration.emission_filter_position))
                     except Exception as e:

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -276,7 +276,7 @@ class OctopiGUI(QMainWindow):
         self.dacControlWidget = widgets.DACControWidget(self.microcontroller)
         self.autofocusWidget = widgets.AutoFocusWidget(self.autofocusController)
         if USE_ZABER_EMISSION_FILTER_WHEEL:
-            self.filterControllerWidget = widgets.FilterControllerWidget(self.emission_filter_wheel, self.liveController.DISABLE_FILTER_WHEEL_MOVEMENT)
+            self.filterControllerWidget = widgets.FilterControllerWidget(self.emission_filter_wheel, self.liveController)
         self.recordingControlWidget = widgets.RecordingWidget(self.streamHandler,self.imageSaver)
         if ENABLE_TRACKING:
             self.trackingControlWidget = widgets.TrackingControllerWidget(self.trackingController,self.configurationManager,show_configurations=TRACKING_SHOW_MICROSCOPE_CONFIGURATIONS)

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -302,6 +302,8 @@ class OctopiGUI(QMainWindow):
         self.navigationWidget = widgets.NavigationWidget(self.navigationController,self.slidePositionController,widget_configuration='384 well plate')
         self.dacControlWidget = widgets.DACControWidget(self.microcontroller)
         self.autofocusWidget = widgets.AutoFocusWidget(self.autofocusController)
+        if USE_ZABER_EMISSION_FILTER_WHEEL:
+            self.filterControllerWidget = widgets.FilterControllerWidget(self.emission_filter_wheel, self.liveController.DISABLE_FILTER_WHEEL_MOVEMENT)
         self.recordingControlWidget = widgets.RecordingWidget(self.streamHandler,self.imageSaver)
         if ENABLE_TRACKING:
             self.trackingControlWidget = widgets.TrackingControllerWidget(self.trackingController,self.configurationManager,show_configurations=TRACKING_SHOW_MICROSCOPE_CONFIGURATIONS)
@@ -329,6 +331,8 @@ class OctopiGUI(QMainWindow):
             self.microscopeControlTabWidget.addTab(self.piezoWidget,"Piezo")
         self.microscopeControlTabWidget.addTab(self.cameraSettingWidget,'Camera')
         self.microscopeControlTabWidget.addTab(self.autofocusWidget,"Contrast AF")
+        if USE_ZABER_EMISSION_FILTER_WHEEL:
+            self.microscopeControlTabWidget.addTab(self.filterControllerWidget,"Filter")
 
         # layout widgets
         layout = QVBoxLayout() #layout = QStackedLayout()

--- a/software/control/serial_peripherals.py
+++ b/software/control/serial_peripherals.py
@@ -451,6 +451,10 @@ class FilterController_Simulation:
     def __init__(self, _baudrate, _bytesize, _parity, _stopbits):
         self.each_hole_microsteps = 4800
         self.current_position = 0
+        '''
+        the variable be used to keep current offset of wheel
+        it could be used by get the index of wheel position, the index could be '1', '2', '3' ... 
+        '''
         self.offset_position = 0
 
         self.deviceinfo = FilterDeviceInfo()
@@ -568,6 +572,9 @@ class FilterController:
         return int(index)
 
     def _move_offset_position(self, offset):
+        '''
+        the function is inner function, be used to move wheel to a given position 
+        '''
         cmd_str = '/move rel ' + str(offset)
         self.send_command(cmd_str)
         timeout = 50
@@ -615,12 +622,18 @@ class FilterController:
         return self.get_index() + 1
 
     def do_homing(self):
+        '''
+        the /home command just make the wheel start to move
+        '''
         self.send_command('/home')
 
     def wait_homing_finish(self):
-        timesout = 100
-        while timesout != 0:
-            timesout -= 1
+        '''
+        the function is used to make the wheel be moving to the setting position 
+        '''
+        timeout_counter = 100
+        while timeout_counter != 0:
+            timeout_counter -= 1
             time.sleep(0.5)
             self.send_command('/get pos')
             result = self.get_position()

--- a/software/control/serial_peripherals.py
+++ b/software/control/serial_peripherals.py
@@ -535,8 +535,13 @@ class FilterController:
     def get_info(self, cmd):
         cmd = cmd + '\n'
         if self.serial.isOpen(): 
-            self.serial.write(cmd.encode('utf-8')) 
-            result = self.serial.readline()
+            try:
+                self.serial.write(cmd.encode('utf-8')) 
+                result = self.serial.readline()
+                if not result:
+                    print("No response from filter controller")
+            except Exception as e:
+                print("Error occurred communicating with filter controller")
             data_string = result.decode('utf-8')
             return_list = data_string.split(' ')
             if return_list[2] == 'OK' and return_list[3] == 'IDLE':

--- a/software/control/serial_peripherals.py
+++ b/software/control/serial_peripherals.py
@@ -575,7 +575,7 @@ class FilterController:
         '''
         the function is inner function, be used to move wheel to a given position 
         '''
-        cmd_str = '/move rel ' + str(self.offset)
+        cmd_str = '/move rel ' + str(self.offset_position)
         self.send_command(cmd_str)
         timeout = 50
         while timeout != 0:
@@ -583,8 +583,8 @@ class FilterController:
             time.sleep(0.1)
             self.send_command('/get pos')
             result = self.get_position()
-            if result[0] == True and result[1] == self.offset:
-                self.current_position = self.offset
+            if result[0] == True and result[1] == self.offset_position:
+                self.current_position = self.offset_position
                 return
         print('filter move offset timeout')
 

--- a/software/control/serial_peripherals.py
+++ b/software/control/serial_peripherals.py
@@ -482,7 +482,7 @@ class FilterController:
     def __init__(self, SN, _baudrate, _bytesize, _parity, _stopbits):
         self.each_hole_microsteps = 4800
         self.current_position = 0
-        self.offset_position = 0
+        self.offset_position = -8500
 
         self.deviceinfo = FilterDeviceInfo()
         optical_mounts_ports = [p.device for p in serial.tools.list_ports.comports() if SN == p.serial_number]
@@ -571,11 +571,11 @@ class FilterController:
         index = (self.current_position - self.offset_position) / self.each_hole_microsteps
         return int(index)
 
-    def _move_offset_position(self, offset):
+    def move_to_offset(self):
         '''
         the function is inner function, be used to move wheel to a given position 
         '''
-        cmd_str = '/move rel ' + str(offset)
+        cmd_str = '/move rel ' + str(self.offset)
         self.send_command(cmd_str)
         timeout = 50
         while timeout != 0:
@@ -583,9 +583,8 @@ class FilterController:
             time.sleep(0.1)
             self.send_command('/get pos')
             result = self.get_position()
-            if result[0] == True and result[1] == self.current_position + offset:
-                self.current_position += offset
-                self.offset_position = offset
+            if result[0] == True and result[1] == self.offset:
+                self.current_position = self.offset
                 return
         print('filter move offset timeout')
 
@@ -639,6 +638,6 @@ class FilterController:
             result = self.get_position()
             if result[0] == True and result[1] == 0:
                 self.current_position = 0
-                self._move_offset_position(1100)
+                self.move_to_offset()
                 return
         print('Filter device homing fail')

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1565,6 +1565,41 @@ class AutoFocusWidget(QFrame):
     def autofocus_is_finished(self):
         self.btn_autofocus.setChecked(False)
 
+
+class FilterControllerWidget(QFrame):
+    def __init__(self, filterController, disable_flag, main=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.filterController = filterController
+        self.disable = disable_flag
+        self.add_components()
+        self.setFrameStyle(QFrame.Panel | QFrame.Raised)
+
+    def add_components(self):
+        self.comboBox = QComboBox()
+        for i in range(1, 8):  # Assuming 7 filter positions
+            self.comboBox.addItem(f"Position {i}")
+        self.checkBox = QCheckBox("Disable filter wheel movement on changing Microscope Configuration", self)
+            
+        layout = QGridLayout()
+        layout.addWidget(QLabel('Filter wheel position:'), 0,0)
+        layout.addWidget(self.comboBox, 0,1)
+        layout.addWidget(self.checkBox, 2,0)
+
+        self.setLayout(layout)
+        
+        self.comboBox.currentIndexChanged.connect(self.on_selection_change)  # Connecting to selection change
+        self.checkBox.stateChanged.connect(self.disable_movement_by_switching_channels)
+
+    def on_selection_change(self, index):
+        # The 'index' parameter is the new index of the combo box
+        if index >= 0 and index <= 7:  # Making sure the index is valid
+            self.filterController.set_emission_filter(index+1)
+
+    def disable_movement_by_switching_channels(self, state):
+        if state:
+            self.disable = True
+
+
 class StatsDisplayWidget(QFrame):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1615,7 +1615,6 @@ class FilterControllerWidget(QFrame):
         layout.addWidget(QLabel('Filter wheel position:'), 0,0)
         layout.addWidget(self.comboBox, 0,1)
         layout.addWidget(self.checkBox, 2,0)
-        layout.addStretch()
 
         self.setLayout(layout)
         

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1598,10 +1598,10 @@ class AutoFocusWidget(QFrame):
 
 
 class FilterControllerWidget(QFrame):
-    def __init__(self, filterController, disable_flag, main=None, *args, **kwargs):
+    def __init__(self, filterController, liveController, main=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.filterController = filterController
-        self.disable = disable_flag
+        self.liveController = liveController
         self.add_components()
         self.setFrameStyle(QFrame.Panel | QFrame.Raised)
 
@@ -1615,6 +1615,7 @@ class FilterControllerWidget(QFrame):
         layout.addWidget(QLabel('Filter wheel position:'), 0,0)
         layout.addWidget(self.comboBox, 0,1)
         layout.addWidget(self.checkBox, 2,0)
+        layout.addStretch()
 
         self.setLayout(layout)
         
@@ -1628,7 +1629,9 @@ class FilterControllerWidget(QFrame):
 
     def disable_movement_by_switching_channels(self, state):
         if state:
-            self.disable = True
+            self.liveController.enable_channel_auto_filter_switching = False
+        else:
+            self.liveController.enable_channel_auto_filter_switching = True
 
 
 class StatsDisplayWidget(QFrame):


### PR DESCRIPTION
Stitching Integration: (ENABLE_STITCHER=True)
added stitcherWidget to software/control/widgets.py

checkbox "Stitch Output" in MultiPointWidget(s) to show stitcher controls
select output-format, apply-flatfield, use-registration
if use-registration, select registration channel, default z-level = 0
allows Stitcher (thread) to communicate with main GUI and acquisition data
status label and progress bar for stitching process
button: "View Output" in StitcherWidget allows us to open the complete stitched acquisition from disk with the correct contrast limits and colors
added Stitcher in software/control/stitcher.py

stitching using one time registration
stitching using dynamic registration (FULL_REGISTRATION=True)
stitch together timepoints and wellplates (STITCH_COMPLETE_ACQUISITION=True)
gets correct pixel data (dz_um size / color)